### PR TITLE
Append '::ISORT' to tests ID

### DIFF
--- a/pytest_isort.py
+++ b/pytest_isort.py
@@ -139,6 +139,7 @@ class IsortItem(pytest.Item, pytest.File):
 
     def __init__(self, path, parent):
         super(IsortItem, self).__init__(path, parent)
+        self._nodeid += "::ISORT"
         self.add_marker('isort')
 
     def setup(self):

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     entry_points={'pytest11': ['isort = pytest_isort']},
     test_suite='.',
     install_requires=[
-        'pytest>=3.0',
+        'pytest>=3.5',
         'isort>=4.0'
     ],
     classifiers=[


### PR DESCRIPTION
Small addition for clearer `pytest` output with `--verbose`.

Before:

```
test.py PASSED
```

After:

```
test.py::ISORT PASSED
```