### PR TITLE
Include tests in pypi sdist archive

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.rst
 include CHANGELOG.rst
 include LICENSE.rst
+include test_isort.py


### PR DESCRIPTION
This allows other users to execute tests and validate the isort against their python stack.