### PR TITLE
Have collect() for IsortItem

### DIFF
--- a/pytest_isort.py
+++ b/pytest_isort.py
@@ -183,3 +183,6 @@ class IsortItem(pytest.Item, pytest.File):
 
     def reportinfo(self):
         return (self.fspath, -1, 'isort-check')
+
+    def collect(self):
+        return iter((self,))


### PR DESCRIPTION
Fixes "NotImplementedError: abstract" with pytest >= 6.1.0.
Implementation copied from https://github.com/tholo/pytest-flake8/pull/71