### PR TITLE
Support for respecting skipped files in the isort native config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 
 install:
   - pip install tox-travis

--- a/test_isort.py
+++ b/test_isort.py
@@ -100,6 +100,22 @@ def test_file_ignored(testdir):
     ])
     assert result.ret == 0
 
+
+def test_file_ignored_in_isort_config(testdir):
+    testdir.tmpdir.ensure("file1.py")
+    testdir.tmpdir.ensure("file2.py")
+
+    isort_cfg = testdir.tmpdir / ".isort.cfg"
+    isort_cfg.write_text("[settings]\nskip = file1.py", encoding="utf-8")
+
+    result = testdir.runpytest('--isort')
+    result.stdout.fnmatch_lines([
+        'file1.py s*',
+        'file2.py .*',
+        '*1 passed, 1 skipped*'
+    ])
+
+
 def test_correctly_sorted(testdir):
     test_file = testdir.makepyfile("""
         import os

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
 skipsdist = True
-envlist = {py36,py37,py38}-{pytest4,pytest5,pytest6}-{isort4,isort5},py35-{pytest4,pytest5,pytest6}-isort4
+envlist = {py36,py37,py38,py39}-{pytest4,pytest5,pytest6}-{isort4,isort5},py35-{pytest4,pytest5,pytest6}-isort4
 
 [tox:travis]
 3.5 = py35
 3.6 = py36
 3.7 = py37
 3.8 = py38
+3.9 = py39
 
 [testenv]
 skip_install = True


### PR DESCRIPTION
Possible solution for #33

Duplicating skipped files in the `isort_ignore` is not really useful, it's better to simply respect the isort config. See the commit message for details.